### PR TITLE
Filter out documentsv2 from documentId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/media-viewer",
-  "version": "2.7.16",
+  "version": "2.7.17-RC.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/media-viewer/package.json
+++ b/projects/media-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/media-viewer",
-  "version": "2.7.16",
+  "version": "2.7.17-RC.1",
   "description": "Media Viewer",
   "keywords": [
     "Angular",

--- a/projects/media-viewer/src/lib/media-viewer.component.ts
+++ b/projects/media-viewer/src/lib/media-viewer.component.ts
@@ -243,8 +243,10 @@ export class MediaViewerComponent implements OnChanges, OnDestroy, AfterContentI
     this.documentTitle = title;
   }
 
+  // If secure mode is enabled (which adds "documentsv2" to the documentId), get rid of it
   private extractDMStoreDocId(url: string): string {
     url = url.includes('/documents/') ? url.split('/documents/')[1] : url;
+    url = url.includes('/documentsv2/') ? url.split('/documentsv2/')[1] : url;
     return url.replace('/binary', '');
   }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-4472


### Change description ###
Filter out "documentsv2" from documentId. This is because when secure mode is enabled, it adds "documentsv2" to the documentId. Release this patch in Angular 8.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
