### PR TITLE
Clear queryList in component destructor to avoid memory leak

### DIFF
--- a/projects/media-viewer/src/lib/annotations/comment-set/comment-set.component.ts
+++ b/projects/media-viewer/src/lib/annotations/comment-set/comment-set.component.ts
@@ -83,6 +83,7 @@ export class CommentSetComponent implements OnInit, OnDestroy, OnChanges {
     if (this.subscriptions.length > 0) {
       this.subscriptions.forEach(subscription => subscription.unsubscribe());
     }
+    this.commentComponents?.destroy();
   }
 
   public onSelect(annotationId: SelectionAnnotation) {


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and its libraries. While running the tool and analyzing the code of em-media-viewer, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found a dangling QueryList that was causing the memory to leak (screenshots below).

[before]
<img width="740" alt="Screen Shot 2023-02-05 at 5 02 13 AM" src="https://user-images.githubusercontent.com/56495631/216790693-a52d0ce6-c68e-4a94-8002-793ef84fbabf.png">

Hence we added the fix by destroying the list in component destructor, and you can see the # of leaks reducing noticeably:
 <br />
<img width="779" alt="Screen Shot 2023-02-05 at 5 11 18 AM" src="https://user-images.githubusercontent.com/56495631/216790699-ed9c169c-16e5-48e7-b963-5329f9299121.png">

We executed the test suite after the fix and it executed 622 of 622  successfully.

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[em-media-viewer-scenario-memlab.txt](https://github.com/hmcts/em-media-viewer/files/10609727/em-media-viewer-scenario-memlab.txt)

Note that some other reported leaks (in Memlab) originated from Angular's internal objects, hence were ignored.