### PR TITLE
EM-6025 :  Resolve PED caseId & list of followers issue 

### DIFF
--- a/projects/media-viewer/src/lib/icp/icp-presenter.service.spec.ts
+++ b/projects/media-viewer/src/lib/icp/icp-presenter.service.spec.ts
@@ -21,6 +21,7 @@ describe('Icp Presenter Service', () => {
 
   const session: IcpSession = {
     caseId: 'caseId',
+    documentId: 'documentId',
     sessionId: 'sessionId',
     dateOfHearing: new Date(),
     connectionUrl: ''

--- a/projects/media-viewer/src/lib/icp/icp-session-api.service.spec.ts
+++ b/projects/media-viewer/src/lib/icp/icp-session-api.service.spec.ts
@@ -9,8 +9,10 @@ describe('IcpSessionApiService', () => {
   let api: IcpSessionApiService;
 
   const caseId = 'caseId';
+  const documentId = 'documentId';
   const session: IcpSession = {
     caseId: 'caseId',
+    documentId: documentId,
     sessionId: 'sessionId',
     dateOfHearing: new Date(),
     connectionUrl: ''
@@ -37,14 +39,14 @@ describe('IcpSessionApiService', () => {
   }));
 
   it('load icp session', fakeAsync((done) => {
-    api.loadSession(caseId)
+    api.loadSession({ caseId: 'caseId', documentId: 'documentId' })
       .subscribe(response => {
         expect(response.username).toBe(username);
         expect(response.session).toBe(session);
       }, error => done(error));
 
-    const req = httpMock.expectOne(`/my-context-path/${caseId}`);
+    const req = httpMock.expectOne(`/my-context-path/${caseId}/${documentId}`);
     expect(req.request.method).toBe('GET');
-    req.flush({session, username});
+    req.flush({ session, username });
   }));
 });

--- a/projects/media-viewer/src/lib/icp/icp-session-api.service.ts
+++ b/projects/media-viewer/src/lib/icp/icp-session-api.service.ts
@@ -9,12 +9,12 @@ export class IcpSessionApiService {
 
   public ICP_SESSION_API = '/icp/sessions';
 
-  constructor(private readonly httpClient: HttpClient) {}
+  constructor(private readonly httpClient: HttpClient) { }
 
-  public loadSession(caseId: string): Observable<any> {
+  public loadSession(payload: { caseId: string, documentId: string }): Observable<any> {
     return this.httpClient
-      .get<{username: string, session: IcpSession}>(`${this.ICP_SESSION_API}/${caseId}`,
-        { observe: 'response' , withCredentials: true })
+      .get<{ username: string, session: IcpSession }>(`${this.ICP_SESSION_API}/${payload.caseId}/${payload.documentId}`,
+        { observe: 'response', withCredentials: true })
       .pipe(map(response => response.body));
   }
 }

--- a/projects/media-viewer/src/lib/icp/icp-update.service.spec.ts
+++ b/projects/media-viewer/src/lib/icp/icp-update.service.spec.ts
@@ -11,6 +11,7 @@ describe('UpdateService', () => {
   const username = 'name';
   const session: IcpSession = {
     caseId: 'caseId',
+    documentId: 'documentId',
     sessionId: 'sessionId',
     dateOfHearing: new Date(),
     connectionUrl: ''

--- a/projects/media-viewer/src/lib/icp/icp-update.service.ts
+++ b/projects/media-viewer/src/lib/icp/icp-update.service.ts
@@ -35,7 +35,9 @@ export class IcpUpdateService {
 
   removeParticipant(participantId) {
     this.socket.emit(IcpEvents.REMOVE_PARTICIPANT, {
-      participantId: participantId, caseId: this.session.caseId
+      participantId: participantId,
+      caseId: this.session.caseId,
+      documentId: this.session.documentId
     });
   }
 
@@ -45,7 +47,9 @@ export class IcpUpdateService {
 
   updatePresenter(presenter: IcpParticipant) {
     this.socket.emit(IcpEvents.UPDATE_PRESENTER, {
-      ...this.session, presenterId: presenter.id, presenterName: presenter.username
+      ...this.session,
+      presenterId: presenter.id,
+      presenterName: presenter.username
     });
   }
 
@@ -54,7 +58,11 @@ export class IcpUpdateService {
   }
 
   updateScreen(screen: IcpScreenUpdate) {
-    const update = { body: screen, caseId: this.session.caseId };
+    const update = {
+      body: screen,
+      caseId: this.session.caseId,
+      documentId: this.session.documentId
+    };
     this.socket.emit(IcpEvents.UPDATE_SCREEN, update);
   }
 

--- a/projects/media-viewer/src/lib/icp/icp.interfaces.ts
+++ b/projects/media-viewer/src/lib/icp/icp.interfaces.ts
@@ -9,6 +9,7 @@ export interface IcpState {
 
 export interface IcpSession {
   sessionId: string;
+  documentId: string;
   caseId: string;
   dateOfHearing: Date;
   connectionUrl: string;

--- a/projects/media-viewer/src/lib/icp/icp.service.spec.ts
+++ b/projects/media-viewer/src/lib/icp/icp.service.spec.ts
@@ -25,14 +25,15 @@ describe('Icp Service', () => {
     clientDisconnected: () => of('client'),
     presenterUpdated: () => of(),
     participantListUpdated: () => of(),
-    leaveSession: () => {},
-    updatePresenter: () => {},
-    screenUpdated: () => {},
-    removeParticipant: () => {},
+    leaveSession: () => { },
+    updatePresenter: () => { },
+    screenUpdated: () => { },
+    removeParticipant: () => { },
   } as any;
 
   const session: IcpSession = {
     caseId: 'caseId',
+    documentId: 'documentId',
     sessionId: 'sessionId',
     dateOfHearing: new Date(),
     connectionUrl: ''
@@ -50,9 +51,9 @@ describe('Icp Service', () => {
       ],
       providers: [IcpService,
         SocketService,
-        {provide: IcpUpdateService, useValue: mockUpdateService},
-        {provide: IcpPresenterService, useValue: mockParticipantService},
-        {provide: IcpFollowerService, useValue: mockParticipantService},
+        { provide: IcpUpdateService, useValue: mockUpdateService },
+        { provide: IcpPresenterService, useValue: mockParticipantService },
+        { provide: IcpFollowerService, useValue: mockParticipantService },
       ]
     });
     service = TestBed.inject(IcpService);
@@ -78,7 +79,7 @@ describe('Icp Service', () => {
     inject([Store, ToolbarEventService], fakeAsync((store, toolbarEvents) => {
       spyOn(service, 'launchSession');
       service.caseId = 'caseId';
-
+      service.documentId = 'documentId';
       toolbarEvents.icp.sessionLaunch.next();
 
       expect(service.launchSession).toHaveBeenCalled();
@@ -90,9 +91,10 @@ describe('Icp Service', () => {
       spyOn(store, 'dispatch');
 
       service.caseId = 'caseId';
+      service.documentId = 'documentId';
       service.launchSession();
 
-      expect(store.dispatch).toHaveBeenCalledWith(new fromIcpActions.LoadIcpSession('caseId'));
+      expect(store.dispatch).toHaveBeenCalledWith(new fromIcpActions.LoadIcpSession({ caseId: 'caseId', documentId: 'documentId' }));
     }))
   );
 
@@ -103,7 +105,7 @@ describe('Icp Service', () => {
       service.caseId = 'caseId';
       service.launchSession();
 
-      const payload = {session: session, participantInfo: {client: participant, presenter: participant}};
+      const payload = { session: session, participantInfo: { client: participant, presenter: participant } };
       const action = new fromIcpActions.IcpSocketSessionJoined(payload);
       store.dispatch(action);
 
@@ -123,7 +125,7 @@ describe('Icp Service', () => {
       toolbarEvents.icp.becomingPresenter.next();
       toolbarEvents.icp.stoppingPresenting.next();
       toolbarEvents.icp.sessionExitConfirmed.next();
-      const payload = {session: session, participantInfo: {client: participant, presenter: participant}};
+      const payload = { session: session, participantInfo: { client: participant, presenter: participant } };
       const action = new fromIcpActions.IcpSocketSessionJoined(payload);
       store.dispatch(action);
       mockUpdateService.clientDisconnected();

--- a/projects/media-viewer/src/lib/icp/icp.service.ts
+++ b/projects/media-viewer/src/lib/icp/icp.service.ts
@@ -9,30 +9,34 @@ import { IcpFollowerService } from './icp-follower.service';
 import { select, Store } from '@ngrx/store';
 import * as fromIcpActions from '../store/actions/icp.actions';
 import * as fromIcpSelectors from '../store/selectors/icp.selectors';
+import * as fromDocument from '../store/selectors/document.selectors';
 import { filter, take } from 'rxjs/operators';
 
 @Injectable()
-export class IcpService implements OnDestroy  {
+export class IcpService implements OnDestroy {
 
   caseId: string;
   client: IcpParticipant;
   presenter: IcpParticipant;
   isPresenter: boolean;
+  documentId: string;
 
   subscription: Subscription;
   sessionSubscription: Subscription;
 
   constructor(private readonly toolbarEvents: ToolbarEventService,
-              private readonly viewerEvents: ViewerEventService,
-              private readonly socketService: IcpUpdateService,
-              private readonly presenterSubscriptions: IcpPresenterService,
-              private readonly followerSubscriptions: IcpFollowerService,
-              private store: Store<IcpState>) {
+    private readonly viewerEvents: ViewerEventService,
+    private readonly socketService: IcpUpdateService,
+    private readonly presenterSubscriptions: IcpPresenterService,
+    private readonly followerSubscriptions: IcpFollowerService,
+    private store: Store<IcpState>) {
     this.subscription = this.store.pipe(select(fromIcpSelectors.getCaseId), filter(value => !!value)).subscribe(caseId => {
       this.caseId = caseId;
     });
+    this.subscription.add(this.store.pipe(select(fromDocument.getDocumentId)).subscribe(docId => this.documentId = docId));
     this.subscription.add(this.toolbarEvents.icp.sessionLaunch.subscribe(() => {
-      if (this.caseId) { this.launchSession(); }
+
+      if (this.caseId && this.documentId) { this.launchSession(); }
     }));
   }
 
@@ -42,9 +46,9 @@ export class IcpService implements OnDestroy  {
   }
 
   launchSession() {
-    this.store.dispatch(new fromIcpActions.LoadIcpSession(this.caseId));
+    this.store.dispatch(new fromIcpActions.LoadIcpSession({ caseId: this.caseId, documentId: this.documentId }));
     this.subscription.add(this.store.pipe(select(fromIcpSelectors.getIcpSession),
-      filter(value => !!value && Object.keys(value).length > 1 ),
+      filter(value => !!value && Object.keys(value).length > 1),
       take(1)).subscribe(() => { this.setUpSessionSubscriptions(); }));
   }
 
@@ -53,20 +57,20 @@ export class IcpService implements OnDestroy  {
     this.sessionSubscription.add(this.toolbarEvents.icp.stoppingPresenting.subscribe(() => this.stopPresenting()));
     this.sessionSubscription.add(this.toolbarEvents.icp.sessionExitConfirmed.subscribe(() => this.leavePresentation()));
     this.sessionSubscription.add(
-      this.store.pipe(select(fromIcpSelectors.getPresenter)).subscribe(presenter => this.presenter = presenter )
+      this.store.pipe(select(fromIcpSelectors.getPresenter)).subscribe(presenter => this.presenter = presenter)
     );
     this.sessionSubscription.add(this.store.pipe(select(fromIcpSelectors.getClient)).subscribe(client => this.client = client));
     this.sessionSubscription.add(this.store.pipe(select(fromIcpSelectors.isPresenter)).subscribe(isPresenter => {
-        this.isPresenter = isPresenter;
-        this.presenterSubscriptions.update(isPresenter);
-        this.followerSubscriptions.update(!isPresenter);
+      this.isPresenter = isPresenter;
+      this.presenterSubscriptions.update(isPresenter);
+      this.followerSubscriptions.update(!isPresenter);
     }));
     this.sessionSubscription.add(this.socketService.clientDisconnected().subscribe(cli => this.clientDisconnected(cli)));
     this.sessionSubscription.add(this.socketService.presenterUpdated().subscribe(pres => {
-        this.store.dispatch(new fromIcpActions.IcpPresenterUpdated(pres));
+      this.store.dispatch(new fromIcpActions.IcpPresenterUpdated(pres));
     }));
     this.sessionSubscription.add(this.socketService.participantListUpdated().subscribe(participants => {
-        this.store.dispatch(new fromIcpActions.IcpParticipantListUpdated(participants));
+      this.store.dispatch(new fromIcpActions.IcpParticipantListUpdated(participants));
     }));
   }
 
@@ -87,7 +91,7 @@ export class IcpService implements OnDestroy  {
   }
 
   stopPresenting() {
-    const presenter: IcpParticipant = {username: '', id: ''};
+    const presenter: IcpParticipant = { username: '', id: '' };
     this.socketService.updatePresenter(presenter);
   }
 

--- a/projects/media-viewer/src/lib/store/actions/icp.actions.spec.ts
+++ b/projects/media-viewer/src/lib/store/actions/icp.actions.spec.ts
@@ -16,10 +16,10 @@ describe('Icp actions', () => {
   describe('Load Session', () => {
     describe('Load Session', () => {
       it('should create an action', () => {
-        const action = new fromIcp.LoadIcpSession('caseId');
+        const action = new fromIcp.LoadIcpSession({ caseId: 'caseId', documentId: 'documentId' });
         expect({ ...action }).toEqual({
           type: fromIcp.LOAD_ICP_SESSION,
-          payload: 'caseId'
+          payload: { caseId: 'caseId', documentId: 'documentId' }
         });
       });
     });
@@ -43,6 +43,7 @@ describe('Icp actions', () => {
           username: 'name',
           session: {
             sessionId: 'sessionId',
+            documentId: 'documentId',
             caseId: 'caseId',
             dateOfHearing: new Date(),
             connectionUrl: 'url-connectionstring'
@@ -70,6 +71,7 @@ describe('Icp actions', () => {
             },
             session: {
               sessionId: 'sessionId',
+              documentId: 'documentId',
               caseId: 'caseId',
               dateOfHearing: new Date(),
               connectionUrl: 'url-connectionstring'

--- a/projects/media-viewer/src/lib/store/actions/icp.actions.ts
+++ b/projects/media-viewer/src/lib/store/actions/icp.actions.ts
@@ -12,42 +12,42 @@ export const ICP_PARTICIPANT_LIST_UPDATED = '[Icp] Participant List Updated';
 
 export class SetCaseId implements Action {
   readonly type = SET_CASE_ID;
-  constructor(public payload: string) {}
+  constructor(public payload: string) { }
 }
 
 export class LoadIcpSession implements Action {
   readonly type = LOAD_ICP_SESSION;
-  constructor(public payload: string) {}
+  constructor(public payload: { caseId: string, documentId: string }) { }
 }
 
 export class LoadIcpSessionFailure implements Action {
   readonly type = LOAD_ICP_SESSION_FAIL;
-  constructor(public payload: Error) {}
+  constructor(public payload: Error) { }
 }
 
 export class JoinIcpSocketSession implements Action {
   readonly type = JOIN_ICP_SOCKET_SESSION;
-  constructor(public payload: { username: string, session: IcpSession }) {}
+  constructor(public payload: { username: string, session: IcpSession }) { }
 }
 
 export class IcpSocketSessionJoined implements Action {
   readonly type = ICP_SOCKET_SESSION_JOINED;
-  constructor(public payload: { session: IcpSession, participantInfo: { client: IcpParticipant, presenter: IcpParticipant } }) {}
+  constructor(public payload: { session: IcpSession, participantInfo: { client: IcpParticipant, presenter: IcpParticipant } }) { }
 }
 
 export class LeaveIcpSocketSession implements Action {
   readonly type = LEAVE_ICP_SOCKET_SESSION;
-  constructor() {}
+  constructor() { }
 }
 
 export class IcpPresenterUpdated implements Action {
   readonly type = ICP_PRESENTER_UPDATED;
-  constructor(public payload: IcpParticipant) {}
+  constructor(public payload: IcpParticipant) { }
 }
 
 export class IcpParticipantListUpdated implements Action {
   readonly type = ICP_PARTICIPANT_LIST_UPDATED;
-  constructor(public payload: any) {}
+  constructor(public payload: any) { }
 }
 
 export type IcpActions =

--- a/projects/media-viewer/src/lib/store/effects/icp.effects.spec.ts
+++ b/projects/media-viewer/src/lib/store/effects/icp.effects.spec.ts
@@ -18,6 +18,7 @@ describe('Icp Effects', () => {
   const icpSocket = jasmine.createSpyObj('IcpUpdateService', ['joinSession']);
   const session: IcpSession = {
     caseId: 'caseId',
+    documentId: 'documentId',
     sessionId: 'sessionId',
     dateOfHearing: new Date(),
     connectionUrl: 'url-connectionstring'
@@ -44,7 +45,7 @@ describe('Icp Effects', () => {
   describe('loadIcpSession$', () => {
     it('should return a JoinSocketSession', () => {
       const payload = { session: session, username: 'name' };
-      const action = new icpActions.LoadIcpSession(session.caseId);
+      const action = new icpActions.LoadIcpSession({ caseId: session.caseId, documentId: session.documentId });
       icpApi.loadSession.and.returnValue(of(payload));
       const completion = new icpActions.JoinIcpSocketSession({ session: session, username: 'name' });
       actions$ = hot('-a', { a: action });
@@ -53,7 +54,7 @@ describe('Icp Effects', () => {
     });
 
     it('should return a LoadSessionFailure', () => {
-      const action = new icpActions.LoadIcpSession(session.caseId);
+      const action = new icpActions.LoadIcpSession({ caseId: session.caseId, documentId: session.documentId });
       icpApi.loadSession.and.returnValue(throwError(new Error()));
       const completion = new icpActions.LoadIcpSessionFailure(new Error());
       actions$ = hot('-a', { a: action });

--- a/projects/media-viewer/src/lib/store/effects/icp.effects.ts
+++ b/projects/media-viewer/src/lib/store/effects/icp.effects.ts
@@ -4,37 +4,37 @@ import { catchError, exhaustMap, map, switchMap } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { IcpSessionApiService } from '../../icp/icp-session-api.service';
 import { IcpUpdateService } from '../../icp/icp-update.service';
-import * as icpActions from '../actions/icp.actions' ;
+import * as icpActions from '../actions/icp.actions';
 import { IcpSession } from '../../icp/icp.interfaces';
 
 @Injectable()
 export class IcpEffects {
 
   constructor(private actions$: Actions,
-              private icpApiService: IcpSessionApiService,
-              private icpUpdateService: IcpUpdateService) {}
+    private icpApiService: IcpSessionApiService,
+    private icpUpdateService: IcpUpdateService) { }
 
   loadIcpSession$ = createEffect(() =>
     this.actions$.pipe(
-    ofType(icpActions.LOAD_ICP_SESSION),
-    map((action: icpActions.LoadIcpSession) => action.payload),
-    exhaustMap((caseId: string) =>
-      this.icpApiService.loadSession(caseId)
-        .pipe(
-          map(res => new icpActions.JoinIcpSocketSession(res)),
-          catchError(error => of(new icpActions.LoadIcpSessionFailure(error)))
-        )
-    ))
+      ofType(icpActions.LOAD_ICP_SESSION),
+      map((action: icpActions.LoadIcpSession) => action.payload),
+      exhaustMap((payload: { caseId: string, documentId: string }) =>
+        this.icpApiService.loadSession(payload)
+          .pipe(
+            map(res => new icpActions.JoinIcpSocketSession(res)),
+            catchError(error => of(new icpActions.LoadIcpSessionFailure(error)))
+          )
+      ))
   );
 
 
   joinIcpSocketSession$ = createEffect(() =>
     this.actions$.pipe(
-    ofType(icpActions.JOIN_ICP_SOCKET_SESSION),
-    map((action: icpActions.JoinIcpSocketSession) => action.payload),
-    switchMap((res: {username: string, session: IcpSession}) =>
-      this.icpUpdateService.joinSession(res.username, res.session)
-        .pipe(map(participants => new icpActions.IcpSocketSessionJoined({session: res.session, participantInfo: participants})))
-    ))
+      ofType(icpActions.JOIN_ICP_SOCKET_SESSION),
+      map((action: icpActions.JoinIcpSocketSession) => action.payload),
+      switchMap((res: { username: string, session: IcpSession }) =>
+        this.icpUpdateService.joinSession(res.username, res.session)
+          .pipe(map(participants => new icpActions.IcpSocketSessionJoined({ session: res.session, participantInfo: participants })))
+      ))
   );
 }

--- a/projects/media-viewer/src/lib/store/reducers/icp.reducer.spec.ts
+++ b/projects/media-viewer/src/lib/store/reducers/icp.reducer.spec.ts
@@ -12,19 +12,20 @@ import {
 const icpState = {
   session: {
     sessionId: 'sessionId',
+    documentId: 'documentId',
     caseId: 'caseId',
     dateOfHearing: new Date(),
     connectionUrl: 'url-connectionstring'
   },
-  client: {id: 'clientId', username: 'name'},
-  presenter: {id: 'presenterId', username: 'name'},
-  participants: [{id: 'participantId', username: 'name'}]
+  client: { id: 'clientId', username: 'name' },
+  presenter: { id: 'presenterId', username: 'name' },
+  participants: [{ id: 'participantId', username: 'name' }]
 };
 
 describe('IcpReducer', () => {
 
   it('should start loading icp state', function () {
-    const state = fromIcp.icpReducer(initialIcpSessionState, new LoadIcpSession('caseId'));
+    const state = fromIcp.icpReducer(initialIcpSessionState, new LoadIcpSession({ caseId: 'caseId', documentId: 'documentId' }));
     expect(state.session).toEqual(null);
     expect(state.client).toEqual(null);
     expect(state.presenter).toEqual(null);
@@ -42,14 +43,14 @@ describe('IcpReducer', () => {
       client: icpState.client,
       presenter: icpState.presenter
     };
-    const state = fromIcp.icpReducer(initialIcpSessionState, new IcpSocketSessionJoined({session, participantInfo}));
+    const state = fromIcp.icpReducer(initialIcpSessionState, new IcpSocketSessionJoined({ session, participantInfo }));
     expect(state.client).toEqual(participantInfo.client);
     expect(state.presenter).toEqual(participantInfo.presenter);
     expect(state.session).toEqual(session);
   });
 
   it('should update presenter', function () {
-    const updatedPresenter = {id: 'newPresenterId', username: 'newPresenterName'};
+    const updatedPresenter = { id: 'newPresenterId', username: 'newPresenterName' };
     const state = fromIcp.icpReducer(icpState, new IcpPresenterUpdated(updatedPresenter));
     expect(state.presenter).toEqual(updatedPresenter);
   });
@@ -62,7 +63,7 @@ describe('IcpReducer', () => {
   });
 
   it('should update participants list', function () {
-    const updatedParticipantsList = {'participantId': 'name'};
+    const updatedParticipantsList = { 'participantId': 'name' };
     const state = fromIcp.icpReducer(initialIcpSessionState, new IcpParticipantListUpdated(updatedParticipantsList));
     expect(state.participants).toEqual(icpState.participants);
   });

--- a/projects/media-viewer/src/lib/store/selectors/icp.selectors.spec.ts
+++ b/projects/media-viewer/src/lib/store/selectors/icp.selectors.spec.ts
@@ -8,6 +8,7 @@ const icpState = {
   session: {
     caseId: 'caseId',
     sessionId: 'sessionId',
+    documentId: "documentId",
     dateOfHearing: new Date(),
     connectionUrl: 'url-connectionstring'
   },


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/EM-6025


### Change description ###
Below are the 2 issues to be resolved as part of this ticket,

Current PED session uses caseId. This needs to be changed to use documentId. This will ensure session is refreshed when presenter refers/presents different document form the same case.
List of Followers is not showing the followers. Currently, we only Presenter shows correctly and followers list does not reflect the followers of the session. 


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
