### PR TITLE
fix: use Puppeteer Chrome in Jenkins and Karma

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -65,6 +65,7 @@ withPipeline(type, product, component) {
   overrideVaultEnvironments(vaultOverrides)
   loadVaultSecrets(secrets)
   enableSecurityScan()
+  env.PUPPETEER_CACHE_DIR = "${env.WORKSPACE}/.cache/puppeteer"
   env.EXECUTE_E2E=false
   env.TEST_URL = 'https://em-media-viewer-staging.service.core-compute-aat.internal/'
   onPR{

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -65,7 +65,6 @@ withPipeline(type, product, component) {
   overrideVaultEnvironments(vaultOverrides)
   loadVaultSecrets(secrets)
   enableSecurityScan()
-  env.PUPPETEER_CACHE_DIR = "${env.WORKSPACE}/.cache/puppeteer"
   env.EXECUTE_E2E=false
   env.TEST_URL = 'https://em-media-viewer-staging.service.core-compute-aat.internal/'
   onPR{
@@ -75,6 +74,7 @@ withPipeline(type, product, component) {
   disableLegacyDeployment()
 
   afterSuccess('checkout') {
+      env.PUPPETEER_CACHE_DIR = "${env.WORKSPACE}/.cache/puppeteer"
       sh ("rm -rf node_modules")
       sh ("yarn cache clean")
       sh ('npm rebuild node-sass')

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -79,6 +79,7 @@ withPipeline(type, product, component) {
       sh ("yarn cache clean")
       sh ('npm rebuild node-sass')
       sh ('yarn install --check-cache')
+      sh ('rm -rf "$PUPPETEER_CACHE_DIR/chrome"')
       sh ('yarn puppeteer browsers install chrome')
       yarnBuilder.yarn('setup')
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -79,13 +79,16 @@ withPipeline(type, product, component) {
       sh ("yarn cache clean")
       sh ('npm rebuild node-sass')
       sh ('yarn install --check-cache')
-      sh ('rm -rf "$PUPPETEER_CACHE_DIR/chrome"')
-      sh ('yarn puppeteer browsers install chrome')
       yarnBuilder.yarn('setup')
   }
 
   afterSuccess('build') {
     yarnBuilder.yarn('build')
+  }
+
+  before('test') {
+    sh ('rm -rf "$PUPPETEER_CACHE_DIR/chrome"')
+    sh ('yarn puppeteer browsers install chrome')
   }
 
   afterAlways('smoketest:preview') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -88,7 +88,7 @@ withPipeline(type, product, component) {
 
   before('test') {
     sh ('rm -rf "$PUPPETEER_CACHE_DIR/chrome"')
-    sh ('yarn puppeteer browsers install chrome')
+    yarnBuilder.yarn('puppeteer browsers install chrome')
   }
 
   afterAlways('smoketest:preview') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -78,6 +78,7 @@ withPipeline(type, product, component) {
       sh ("yarn cache clean")
       sh ('npm rebuild node-sass')
       sh ('yarn install --check-cache')
+      sh ('yarn puppeteer browsers install chrome')
       yarnBuilder.yarn('setup')
   }
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -78,6 +78,7 @@ withNightlyPipeline(type, product, component) {
     sh ("yarn cache clean")
     sh ('npm rebuild node-sass')
     sh ('yarn install --check-cache')
+    sh ('rm -rf "$PUPPETEER_CACHE_DIR/chrome"')
     sh ('yarn puppeteer browsers install chrome')
     yarnBuilder.yarn('setup')
   }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -65,6 +65,7 @@ withNightlyPipeline(type, product, component) {
   env.RUNNING_ENV = params.ENVIRONMENT
   overrideVaultEnvironments(vaultOverrides)
   loadVaultSecrets(secrets)
+  env.PUPPETEER_CACHE_DIR = "${env.WORKSPACE}/.cache/puppeteer"
 
   disableLegacyDeployment()
   enableSecurityScan()

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -65,7 +65,6 @@ withNightlyPipeline(type, product, component) {
   env.RUNNING_ENV = params.ENVIRONMENT
   overrideVaultEnvironments(vaultOverrides)
   loadVaultSecrets(secrets)
-  env.PUPPETEER_CACHE_DIR = "${env.WORKSPACE}/.cache/puppeteer"
 
   disableLegacyDeployment()
   enableSecurityScan()
@@ -74,6 +73,7 @@ withNightlyPipeline(type, product, component) {
   enableCrossBrowserTest()
 
   afterSuccess('checkout') {
+    env.PUPPETEER_CACHE_DIR = "${env.WORKSPACE}/.cache/puppeteer"
     sh ("rm -rf node_modules")
     sh ("yarn cache clean")
     sh ('npm rebuild node-sass')

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -77,6 +77,7 @@ withNightlyPipeline(type, product, component) {
     sh ("yarn cache clean")
     sh ('npm rebuild node-sass')
     sh ('yarn install --check-cache')
+    sh ('yarn puppeteer browsers install chrome')
     yarnBuilder.yarn('setup')
   }
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -78,8 +78,6 @@ withNightlyPipeline(type, product, component) {
     sh ("yarn cache clean")
     sh ('npm rebuild node-sass')
     sh ('yarn install --check-cache')
-    sh ('rm -rf "$PUPPETEER_CACHE_DIR/chrome"')
-    sh ('yarn puppeteer browsers install chrome')
     yarnBuilder.yarn('setup')
   }
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,8 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
+process.env.CHROME_BIN = require('puppeteer').executablePath();
+
 module.exports = function (config) {
   config.set({
     basePath: '',
@@ -33,7 +35,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadless'],
+    browsers: ['ChromeHeadlessCI'],
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
     singleRun: true,
     restartOnFileChange: true
   });

--- a/projects/media-viewer/karma.conf.js
+++ b/projects/media-viewer/karma.conf.js
@@ -1,6 +1,8 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
+process.env.CHROME_BIN = require('puppeteer').executablePath();
+
 module.exports = function (config) {
     config.set({
       basePath: '',
@@ -38,7 +40,7 @@ module.exports = function (config) {
       colors: true,
       logLevel: config.LOG_INFO,
       autoWatch: true,
-      browsers: ['ChromeHeadless'],
+      browsers: ['ChromeHeadlessCI'],
       customLaunchers: {
         ChromeHeadlessCI: {
           base: 'ChromeHeadless',
@@ -49,4 +51,3 @@ module.exports = function (config) {
       restartOnFileChange: true
     });
   };
-  

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -1,6 +1,8 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
+process.env.CHROME_BIN = require('puppeteer').executablePath();
+
 module.exports = function (config) {
     config.set({
     basePath: '',
@@ -33,7 +35,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadless'],
+    browsers: ['ChromeHeadlessCI'],
+    customLaunchers: {
+        ChromeHeadlessCI: {
+            base: 'ChromeHeadless',
+            flags: ['--no-sandbox']
+        }
+    },
     singleRun: true,
     restartOnFileChange: true
     });


### PR DESCRIPTION
### What changed

- Configure Jenkins to use a workspace-local Puppeteer cache and install the Puppeteer-managed Chrome browser after `yarn install --check-cache`.
- Point Karma at `require('puppeteer').executablePath()` so tests use the browser version resolved by the current Puppeteer package.
- Register `ChromeHeadlessCI` with `--no-sandbox` in all repo Karma configs used by the Angular test command.

### Why

The master media-viewer pipeline started failing after the Puppeteer bump because the Chrome version managed by Puppeteer was no longer available to Karma/Jenkins by default. Installing the Puppeteer browser in Jenkins and wiring Karma to Puppeteer's executable path removes the dependency on an ambient Chrome binary.

### Validation

- `yarn install --check-cache` passed with warnings.
- `yarn puppeteer browsers install chrome` passed and installed Chrome for Testing `147.0.7727.57`.
- `node --check projects/media-viewer/karma.conf.js && node --check src/karma.conf.js && node --check karma.conf.js` passed.
- `yarn lint` passed.
- `yarn test --watch=false --browsers=ChromeHeadlessCI` passed:
  - `TOTAL: 922 SUCCESS`
  - `TOTAL: 2 SUCCESS`
- `yarn npm audit --recursive --environment production` failed due existing production advisories on the current dependency tree, including Angular `20.3.19`, `form-data`, `lodash`, and `ws`. This PR does not change package manifests or the lockfile.

### Security Vulnerability Assessment

- CVE suppression added: No
- Dependency changes: No
- Existing audit risk: Yes, unchanged by this PR

### Checklist

- [x] Code builds/lints locally
- [x] Chrome/Karma path validated locally
- [x] No direct push to `master`
- [ ] Human review before merge